### PR TITLE
Add handedness layout to support chordal_hold_layout in QMK

### DIFF
--- a/firmware/keymaps/vial/keymap.c
+++ b/firmware/keymaps/vial/keymap.c
@@ -62,3 +62,12 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                                             KC_TRNS, KC_TRNS, KC_TRNS,           KC_TRNS,  KC_TRNS,  KC_TRNS
     )
 };
+
+const char chordal_hold_layout[MATRIX_ROWS][MATRIX_COLS] PROGMEM =
+    LAYOUT(
+        'L', 'L', 'L', 'L', 'L', 'L',  'R', 'R', 'R', 'R', 'R', 'R', 
+        'L', 'L', 'L', 'L', 'L', 'L',  'R', 'R', 'R', 'R', 'R', 'R', 
+        'L', 'L', 'L', 'L', 'L', 'L',  'R', 'R', 'R', 'R', 'R', 'R', 
+        'L', 'L', 'L', 'L', 'L', 'L',  'R', 'R', 'R', 'R', 'R', 'R', 
+                       'L', 'L', 'L',  'R', 'R', 'R'
+    );


### PR DESCRIPTION
This PR adds support for the `chordal_hold_layout` function described in the [QMK Tap-Hold documentation](https://docs.qmk.fm/tap_hold#chordal-hold-handedness).

It addresses the issues outlined in #18 where the Chordal Hold option in Vial is selected, but the behavior of the handedness is inconsistent with the hands of the keyboard.

Pre-test (if desired):
1. Set the options described in Issue #18 
2. Observe the homerow behavior of the fppf and jppj nested strokes

To test:

1. Check out the branch for this PR and build the vial firmware
2. Flash the firmware to your board and open Vial
3. Set the options as described in #18, but importantly, check the Chordal Hold option
4. Observe the behavior outlined in the pre-test has changed:
  1. The nested keystroke combination of fppf produces a `P` as expected
  2. The nested keystroke combination of jppj produces a `jp` as expected when the Chordal Hold option is selected

No other behavior appears to be negatively impacted by this change.

Thanks and let me know if you have any questions.  